### PR TITLE
Allow admins to edit users who haven't authorized any backends

### DIFF
--- a/src/officehours_api/models.py
+++ b/src/officehours_api/models.py
@@ -53,7 +53,7 @@ class Profile(models.Model):
     phone_number = models.CharField(max_length=20, default="", blank=True, null=False)
     notify_me_attendee = models.BooleanField(default=False)
     notify_me_host = models.BooleanField(default=False)
-    backend_metadata = JSONField(null=True, default=dict)
+    backend_metadata = JSONField(null=True, default=dict, blank=True)
 
     @property
     def authorized_backends(self):


### PR DESCRIPTION
 an issue that occurs when an admin attempts to edit a user and the `backend_metadata` field considers {} as empty.

The issue arises because JSONField treats the following as empty values:
`EMPTY_VALUES = (None, '', [], (), {})`

As a result, the auto-filled `{}` cannot be directly saved when the field is required. This PR addresses the issue by adding the `blank="True"` attribute to `backend_metadata`, allowing `{}` to be saved.

Since the original `backend_metadata` field permits null, it should be safe to make the field not required. It may be also necessary to update all `backend_metadata` fields if this works.